### PR TITLE
docs: fix github action doc token naming consistency

### DIFF
--- a/docs/recce-cloud/setup-gh-actions.md
+++ b/docs/recce-cloud/setup-gh-actions.md
@@ -119,7 +119,7 @@ jobs:
         run: |
           recce cloud upload-artifacts
         env:
-          GITHUB_TOKEN: ${{ secrets.RECCE_CLOUD_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           RECCE_STATE_PASSWORD: ${{ secrets.RECCE_STATE_PASSWORD}}
 ```
 
@@ -185,7 +185,7 @@ jobs:
         run: |
           recce cloud download-base-artifacts
         env:
-          GITHUB_TOKEN: ${{ secrets.RECCE_CLOUD_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           RECCE_STATE_PASSWORD: ${{ secrets.RECCE_STATE_PASSWORD}}
 
       - name: Prepare the PR environment
@@ -205,7 +205,7 @@ jobs:
         run: |
           recce cloud upload-artifacts
         env:
-          GITHUB_TOKEN: ${{ secrets.RECCE_CLOUD_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           RECCE_STATE_PASSWORD: ${{ secrets.RECCE_STATE_PASSWORD}}
 
       - name: Prepare Recce Summary


### PR DESCRIPTION
Replaced `RECCE_CLOUD_TOKEN` with `GH_TOKEN` for better understanding and consistency.

Original from: https://github.com/DataRecce/recce-documentation/pull/182