### PR TITLE
docs: Update devcontainer config for outdated version specification

### DIFF
--- a/docs/recce-cloud/setup-gh-codespaces.md
+++ b/docs/recce-cloud/setup-gh-codespaces.md
@@ -40,10 +40,12 @@ GitHub Codespaces is a development environment provided by GitHub that allows de
     - or [Repository-level or organization-level codespaces secrets](https://docs.github.com/en/codespaces/managing-codespaces-for-your-organization/managing-development-environment-secrets-for-your-repository-or-organization)
 
 1. Prepare the `.devcontainer/Dockerfile`
+    For environment setup, you need to install `recce`, dbt and the appropriate adapter for your data platform.
+    Below is a sample Dockerfile for BigQuery. You can customize it based on your needs.
     ```
     FROM mcr.microsoft.com/vscode/devcontainers/python:3.11
 
-    RUN pip install dbt-bigquery~=1.7.0 recce~=0.34
+    RUN pip install dbt-core dbt-bigquery recce
     ```
 !!!Note
 

--- a/docs/recce-cloud/setup-gh-codespaces.md
+++ b/docs/recce-cloud/setup-gh-codespaces.md
@@ -41,7 +41,7 @@ GitHub Codespaces is a development environment provided by GitHub that allows de
 
 1. Prepare the `.devcontainer/Dockerfile`
 
-    For environment setup, you need to install `recce`, `dbt` and the appropriate adapter for your data platform.
+    For environment setup, you need to install `recce`, `dbt`, and the appropriate adapter for your data platform.
 
     Below is a sample Dockerfile for BigQuery. You can customize it based on your needs.
     ```

--- a/docs/recce-cloud/setup-gh-codespaces.md
+++ b/docs/recce-cloud/setup-gh-codespaces.md
@@ -40,7 +40,9 @@ GitHub Codespaces is a development environment provided by GitHub that allows de
     - or [Repository-level or organization-level codespaces secrets](https://docs.github.com/en/codespaces/managing-codespaces-for-your-organization/managing-development-environment-secrets-for-your-repository-or-organization)
 
 1. Prepare the `.devcontainer/Dockerfile`
-    For environment setup, you need to install `recce`, dbt and the appropriate adapter for your data platform.
+
+    For environment setup, you need to install `recce`, `dbt` and the appropriate adapter for your data platform.
+
     Below is a sample Dockerfile for BigQuery. You can customize it based on your needs.
     ```
     FROM mcr.microsoft.com/vscode/devcontainers/python:3.11


### PR DESCRIPTION
- Current version specifications are outdated
- Make it version-agnostic for a general example

<img width="723" alt="截圖 2025-05-20 晚上9 32 54" src="https://github.com/user-attachments/assets/87e4e9b1-fca5-4593-99b0-931ae9bf6b31" />

