### PR TITLE
update demo link

### DIFF
--- a/docs/demo.md
+++ b/docs/demo.md
@@ -7,7 +7,7 @@ icon: material/keyboard
 
 We provide interactive demos that show common ways to use Recce. You can try them right now without installing anything.
 
-[Try Demos](https://reccehq.com/demo/){ .md-button .md-button--primary } (No install)
+[Check out Demos](https://reccehq.com/demo/){ .md-button .md-button--primary } (No install)
 
 ## Examples
 

--- a/docs/demo.md
+++ b/docs/demo.md
@@ -5,10 +5,9 @@ icon: material/keyboard
 
 # Interactive Demos
 
-Try `Recce` without installing using this [online demo](https://reccehq.com/demo/).
+We provide interactive demos that show common ways to use Recce. You can try them right now without installing anything.
 
-[Recce Online Demo](https://reccehq.com/demo/){ .md-button .md-button--primary }
-
+[Try Demos](https://reccehq.com/demo/){ .md-button .md-button--primary } (No install)
 
 ## Examples
 

--- a/docs/demo.md
+++ b/docs/demo.md
@@ -1,20 +1,13 @@
 ---
-title: Online Demo
+title: Interactive Demos
 icon: material/keyboard
 ---
 
-# Recce Online Demo
+# Interactive Demos
 
-Try `Recce` without installing using this [online demo](https://pr1.demo.reccehq.com).
+Try `Recce` without installing using this [online demo](https://reccehq.com/demo/).
 
-[Recce Online Demo](https://pr1.demo.reccehq.com){ .md-button .md-button--primary }
-
-The demo showcases a [pull request](https://github.com/DataRecce/jaffle_shop_duckdb/pull/1) that fixes the `customer_lifetime_value` calculation in dbt's Jaffle Shop project to only included completed orders.
-
-<figure markdown>
-  ![customers.sql](assets/images/demo/clv-customers-model-fs8.png){: .shadow}
-  <figcaption>Jaffle Shop customers.sql</figcaption>
-</figure>
+[Recce Online Demo](https://reccehq.com/demo/){ .md-button .md-button--primary }
 
 
 ## Examples

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,15 +26,7 @@ Recce is the foundation of the workflow. It helps you explore changes, validate 
 
 ### Explore the Live Demos
 
-Want to see Recce in action without setting anything up? Try it with real pull requests from the Jaffle Shop demo project.
-
-Each PR shows how Recce helps validate dbt model changes with lineage, diffs, and review checklists.
-
-- [PR #1](https://github.com/DataRecce/jaffle_shop_duckdb/pull/1) – Fixing logic in Customer Lifetime Value
-- [PR #2](https://github.com/DataRecce/jaffle_shop_duckdb/pull/2) – Refactoring for clarity
-- [PR #3](https://github.com/DataRecce/jaffle_shop_duckdb/pull/3) – Adding rounding analysis
-- [PR #44](https://github.com/DataRecce/jaffle_shop_duckdb/pull/44) – Enhancing the customers model
-- [PR #46](https://github.com/DataRecce/jaffle_shop_duckdb/pull/46) – fixing metrics, rebuilding trust
+Want to see Recce in action without setting anything up? Try [interactive demos](https://reccehq.com/demo/). 
 
 ## Why Recce
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,7 +26,7 @@ Recce is the foundation of the workflow. It helps you explore changes, validate 
 
 ### Explore the Live Demos
 
-Want to see Recce in action without setting anything up? Try [interactive demos](https://reccehq.com/demo/). 
+Want to see Recce in action without setting anything up? Check out the [interactive demos](https://reccehq.com/demo/). 
 
 ## Why Recce
 

--- a/docs/styles/extra.css
+++ b/docs/styles/extra.css
@@ -6,6 +6,14 @@
   margin-right: 0.1rem;
   vertical-align: top;
 }
+
+.md-nav__item a.md-nav__link[href^="https://reccehq.com/demo/"] .md-ellipsis::before {
+  content: "⌨";
+  display: inline-block;
+  margin-right: 0.1rem;
+  vertical-align: top;
+  font-size: 1rem;
+}
 .md-nav__item a.md-nav__link[href^="https://"]:hover .md-ellipsis::before {
   filter: invert(46%) sepia(13%) saturate(2575%) hue-rotate(326deg) brightness(115%) contrast(106%);
 }

--- a/docs/styles/extra.css
+++ b/docs/styles/extra.css
@@ -7,13 +7,6 @@
   vertical-align: top;
 }
 
-.md-nav__item a.md-nav__link[href^="https://reccehq.com/demo/"] .md-ellipsis::before {
-  content: "⌨";
-  display: inline-block;
-  margin-right: 0.1rem;
-  vertical-align: top;
-  font-size: 1rem;
-}
 .md-nav__item a.md-nav__link[href^="https://"]:hover .md-ellipsis::before {
   filter: invert(46%) sepia(13%) saturate(2575%) hue-rotate(326deg) brightness(115%) contrast(106%);
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -35,7 +35,7 @@ nav:
   - Guides:
       - Overview:
           - index.md
-          - demo.md
+          - Interactive Demos: "https://reccehq.com/demo/"
       - Getting Started:
           - get-started.md
           - configure-diff.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -35,7 +35,7 @@ nav:
   - Guides:
       - Overview:
           - index.md
-          - Interactive Demos: "https://reccehq.com/demo/"
+          - demo.md
       - Getting Started:
           - get-started.md
           - configure-diff.md


### PR DESCRIPTION
[PLA-464](https://linear.app/recce/issue/PLA-464/update-doc-that-has-demo-link-and-description-after-new-demo-page)

but I need help to update the icon with "Interactive Demos" on the navigation