### PR TITLE
feat(robots): publish robots.txt with AI bot rules + Content-Signal on docs

### DIFF
--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,0 +1,21 @@
+# https://contentsignals.org/
+User-agent: *
+Content-Signal: search=yes, ai-input=no, ai-train=no
+Allow: /
+
+User-agent: GPTBot
+Allow: /
+User-agent: ChatGPT-User
+Allow: /
+User-agent: ClaudeBot
+Allow: /
+User-agent: anthropic-ai
+Allow: /
+User-agent: Google-Extended
+Allow: /
+User-agent: PerplexityBot
+Allow: /
+User-agent: CCBot
+Allow: /
+
+Sitemap: https://docs.reccehq.com/sitemap.xml


### PR DESCRIPTION
## Summary
- Adds `/robots.txt` to docs.reccehq.com (currently returns 404)
- Wildcard + 7 per-bot Allow blocks (GPTBot, ChatGPT-User, ClaudeBot, anthropic-ai, Google-Extended, PerplexityBot, CCBot)
- Content-Signal: `search=yes, ai-input=no, ai-train=no`

## Why
Unblocks three scanner checks at once on docs.reccehq.com — `robotsTxt`, `robotsTxtAiRules`, `contentSignals`. Single biggest gap; moves docs from Level 0 to Level 2.

## Content-Signal policy (decision recorded per plan §A)
Defaulting to **conservative variant** matching the scanner's SKILL.md example. Swap to `ai-input=yes` if product/legal prefer.

## Test plan
- [ ] After deploy: `curl -sI https://docs.reccehq.com/robots.txt` returns 200 with `text/plain`
- [ ] Body includes per-bot blocks and Content-Signal
- [ ] Re-scan: `scripts/agent-readiness-scan.sh https://docs.reccehq.com` shows `robotsTxt: pass`, `robotsTxtAiRules: pass`, `contentSignals: pass`, `level >= 2`

Resolves DRC-3413.