### PR TITLE
feat(llms): generate llms-full.txt at build time

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -220,5 +220,8 @@ plugins:
       cards_layout_options:
         background_color: "#2A6CA7"
 
+hooks:
+  - scripts/build_llms_full.py
+
 watch:
   - docs

--- a/scripts/build_llms_full.py
+++ b/scripts/build_llms_full.py
@@ -1,6 +1,8 @@
 """Concatenate all rendered docs into site/llms-full.txt."""
 from __future__ import annotations
 
+import html
+import logging
 import re
 from pathlib import Path
 from urllib.parse import urlparse
@@ -10,12 +12,15 @@ from mkdocs.plugins import event_priority
 
 EXPECTED_HOST = "docs.reccehq.com"
 
+log = logging.getLogger("mkdocs")
+
 
 @event_priority(-100)
 def on_post_build(config: MkDocsConfig) -> None:
     site = Path(config["site_dir"])
     sitemap_path = site / "sitemap.xml"
     if not sitemap_path.exists():
+        log.warning("build_llms_full: %s not found, skipping llms-full.txt", sitemap_path)
         return
     sitemap = sitemap_path.read_text(encoding="utf-8")
     urls = sorted(set(re.findall(r"<loc>(.*?)</loc>", sitemap)))
@@ -27,29 +32,28 @@ def on_post_build(config: MkDocsConfig) -> None:
         rel = parsed.path.strip("/")
         html_path = site / rel / "index.html" if rel else site / "index.html"
         if not html_path.exists():
+            log.warning("build_llms_full: missing %s for sitemap URL %s", html_path, url)
             continue
-        html = html_path.read_text(encoding="utf-8")
-        main = re.search(r"<main[^>]*>(.*?)</main>", html, re.DOTALL)
-        if not main:
+        page_html = html_path.read_text(encoding="utf-8")
+        # Material puts nav and TOC sidebars inside <main>, so selecting <main>
+        # would duplicate the entire nav tree into every section. The actual
+        # page content lives in <article class="md-content__inner">.
+        article = re.search(
+            r'<article[^>]*class="[^"]*md-content__inner[^"]*"[^>]*>(.*?)</article>',
+            page_html,
+            re.DOTALL,
+        )
+        if not article:
+            log.warning("build_llms_full: no md-content__inner article in %s", html_path)
             continue
-        body = main.group(1)
+        body = article.group(1)
         # Strip script/style blocks before tag-stripping to avoid CSS/JS leakage.
         body = re.sub(r"<script[^>]*>.*?</script>", " ", body, flags=re.DOTALL | re.IGNORECASE)
         body = re.sub(r"<style[^>]*>.*?</style>", " ", body, flags=re.DOTALL | re.IGNORECASE)
         body = re.sub(r"<noscript[^>]*>.*?</noscript>", " ", body, flags=re.DOTALL | re.IGNORECASE)
-        # Strip HTML comments.
         body = re.sub(r"<!--.*?-->", " ", body, flags=re.DOTALL)
-        # Strip remaining tags.
         text = re.sub(r"<[^>]+>", " ", body)
-        # Decode common HTML entities.
-        text = (
-            text.replace("&nbsp;", " ")
-            .replace("&amp;", "&")
-            .replace("&lt;", "<")
-            .replace("&gt;", ">")
-            .replace("&quot;", '"')
-            .replace("&#39;", "'")
-        )
+        text = html.unescape(text)
         text = re.sub(r"\s+", " ", text).strip()
         if not text:
             continue

--- a/scripts/build_llms_full.py
+++ b/scripts/build_llms_full.py
@@ -1,0 +1,51 @@
+"""Concatenate all rendered docs into site/llms-full.txt."""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from mkdocs.config.defaults import MkDocsConfig
+from mkdocs.plugins import event_priority
+
+
+@event_priority(-100)
+def on_post_build(config: MkDocsConfig) -> None:
+    site = Path(config["site_dir"])
+    sitemap_path = site / "sitemap.xml"
+    if not sitemap_path.exists():
+        return
+    sitemap = sitemap_path.read_text(encoding="utf-8")
+    urls = sorted(set(re.findall(r"<loc>(.*?)</loc>", sitemap)))
+    parts: list[str] = ["# Recce Documentation — Full Corpus\n"]
+    for url in urls:
+        rel = url.rsplit("docs.reccehq.com/", 1)[-1].rstrip("/")
+        html_path = site / rel / "index.html" if rel else site / "index.html"
+        if not html_path.exists():
+            continue
+        html = html_path.read_text(encoding="utf-8")
+        main = re.search(r"<main[^>]*>(.*?)</main>", html, re.DOTALL)
+        if not main:
+            continue
+        body = main.group(1)
+        # Strip script/style blocks before tag-stripping to avoid CSS/JS leakage.
+        body = re.sub(r"<script[^>]*>.*?</script>", " ", body, flags=re.DOTALL | re.IGNORECASE)
+        body = re.sub(r"<style[^>]*>.*?</style>", " ", body, flags=re.DOTALL | re.IGNORECASE)
+        body = re.sub(r"<noscript[^>]*>.*?</noscript>", " ", body, flags=re.DOTALL | re.IGNORECASE)
+        # Strip HTML comments.
+        body = re.sub(r"<!--.*?-->", " ", body, flags=re.DOTALL)
+        # Strip remaining tags.
+        text = re.sub(r"<[^>]+>", " ", body)
+        # Decode common HTML entities.
+        text = (
+            text.replace("&nbsp;", " ")
+            .replace("&amp;", "&")
+            .replace("&lt;", "<")
+            .replace("&gt;", ">")
+            .replace("&quot;", '"')
+            .replace("&#39;", "'")
+        )
+        text = re.sub(r"\s+", " ", text).strip()
+        if not text:
+            continue
+        parts.append(f"\n\n---\n## {url}\n\n{text}")
+    (site / "llms-full.txt").write_text("\n".join(parts), encoding="utf-8")

--- a/scripts/build_llms_full.py
+++ b/scripts/build_llms_full.py
@@ -3,9 +3,12 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
+from urllib.parse import urlparse
 
 from mkdocs.config.defaults import MkDocsConfig
 from mkdocs.plugins import event_priority
+
+EXPECTED_HOST = "docs.reccehq.com"
 
 
 @event_priority(-100)
@@ -18,7 +21,10 @@ def on_post_build(config: MkDocsConfig) -> None:
     urls = sorted(set(re.findall(r"<loc>(.*?)</loc>", sitemap)))
     parts: list[str] = ["# Recce Documentation — Full Corpus\n"]
     for url in urls:
-        rel = url.rsplit("docs.reccehq.com/", 1)[-1].rstrip("/")
+        parsed = urlparse(url)
+        if parsed.netloc and parsed.netloc != EXPECTED_HOST:
+            continue
+        rel = parsed.path.strip("/")
         html_path = site / rel / "index.html" if rel else site / "index.html"
         if not html_path.exists():
             continue


### PR DESCRIPTION
## Summary
- Adds `scripts/build_llms_full.py` mkdocs hook
- Generates `site/llms-full.txt` on every build, anchored on sitemap.xml

## Why
Single-context-window corpus for agents grounding answers about Recce. Part of agent-readiness Level 3 work.

## Implementation notes
- Sitemap-anchored (not glob) so nav exclusions + redirect plugins don't hide pages.
- Strips `<script>`/`<style>`/`<noscript>` and HTML comments first, then strips remaining tags via regex.
- Decodes common HTML entities (`&nbsp;`, `&amp;`, `&lt;`, etc.).
- Only `<main>` content is included — frontmatter / nav / footer are excluded.

## Test plan
- [x] `uv run mkdocs build` produces `site/llms-full.txt` (216 KB, 36 sections)
- [x] First 5 sections look clean (no `<script>`, `<style>`, `<div>`, `&nbsp;`, `&amp;` leakage)
- [ ] After deploy: `curl -sI https://docs.reccehq.com/llms-full.txt` returns 200 with `text/plain`

Resolves DRC-3416.