### PR TITLE
ci(deploy): retry gh-deploy on transient GitHub 500

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,27 @@ jobs:
           path: .cache
           restore-keys: |
             mkdocs-material-
-      - run: pip install -r requirements.txt 
-      - run: mkdocs gh-deploy --force
-      
+      - run: pip install -r requirements.txt
+      # gh-deploy occasionally hits a transient HTTP 500 from GitHub on the
+      # push to gh-pages (see run 25674953089). Retry a few times before
+      # failing the job so a one-off blip doesn't take docs.reccehq.com down.
+      - name: Deploy to gh-pages (with retry)
+        env:
+          DISABLE_MKDOCS_2_WARNING: "true"
+        run: |
+          set -e
+          attempts=3
+          delay=15
+          for i in $(seq 1 "$attempts"); do
+            if mkdocs gh-deploy --force; then
+              echo "Deploy succeeded on attempt $i"
+              exit 0
+            fi
+            if [ "$i" -lt "$attempts" ]; then
+              echo "Deploy attempt $i failed; retrying in ${delay}s..."
+              sleep "$delay"
+              delay=$((delay * 2))
+            fi
+          done
+          echo "Deploy failed after $attempts attempts"
+          exit 1


### PR DESCRIPTION
## Summary

Make the `mkdocs gh-deploy` step resilient to transient GitHub 500s so a one-off blip stops taking `docs.reccehq.com` out of date until someone manually reruns the job.

## What happened

Run [25674953089](https://github.com/DataRecce/recce-docs/actions/runs/25674953089) (the deploy for the PR #100 merge) failed at `git push origin gh-pages --force` with:

```
remote: Internal Server Error
fatal: unable to access 'https://github.com/DataRecce/recce-docs/': The requested URL returned error: 500
```

The build itself succeeded cleanly:

```
INFO    -  build_md_mirrors: wrote 37 .md mirrors and sitemap.md
INFO    -  Documentation built in 1.17 seconds
INFO    -  Copying '.../site' to 'gh-pages' branch and pushing to GitHub.
remote: Internal Server Error
```

I manually re-ran the failed job and it succeeded with no other changes. `gh-pages` now points at the PR #100 merge commit, and the live site is serving the new content (`AGENTS.md`, `sitemap.md`, `glossary/`, `.md` mirrors all return 200). So the failure was on GitHub's side, not anything PR #100 did.

The risk is the next transient 500 doing the same thing.

## Fix

Wrap `mkdocs gh-deploy --force` in a 3-attempt loop with exponential backoff (15s, then 30s between retries). On success, exit immediately. On the third failure, fail the job as before. Also set `DISABLE_MKDOCS_2_WARNING=true` to silence the ProperDocs marketing banner that a recent plugin update started printing into the log.

## Test plan

- [x] Lint workflow YAML mentally and confirm shell loop exits with status 0 on first success / 1 after all retries.
- [ ] After merge, the next push to `main` exercises the new step; if no transient 500 occurs it should look identical to today's successful deploy. If a 500 occurs, look for "Deploy attempt 1 failed; retrying in 15s..." in the log.

Generated with [Claude Code](https://claude.com/claude-code)
