### PR TITLE
chore(a14y): record post-deploy audit score 72/100

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -82,4 +82,5 @@ For the CLI reference, see <https://docs.reccehq.com/using-recce/cli-commands/>.
 - Scorecard: 0.2.0
 - Mode: site
 - Last runs:
+  - 2026-05-11 — 72 (scorecard 0.2.0)
   - 2026-05-11 — 66 (scorecard 0.2.0)


### PR DESCRIPTION
## Summary

Records the post-deploy a14y audit score for [PR #100](https://github.com/DataRecce/recce-docs/pull/100) into `docs/AGENTS.md`'s `## a14y configuration` block.

```
Score: 66 -> 72 (+6)
```

Audit run against the live `https://docs.reccehq.com/` at 2026-05-11T14:13 UTC, scorecard v0.2.0, 989/1372 checks passed.

## Resolved

- `agents-md.has-min-sections` (site-wide)
- `llms-txt.md-extensions` (site-wide)
- `sitemap-md.exists` (site-wide)
- `html.glossary-link` (37 -> 1; remaining 1 is the Cloudflare email-protection intercept page)
- `html.json-ld` (37 -> 1)
- `markdown.alternate-link` (37 -> 1)
- `markdown.mirror-suffix` (37 -> 1)

## Still failing (default-skipped or out of scope)

- `markdown.content-negotiation` (38 pages): origin-server fix.
- `html.text-ratio` (36 pages): theme chrome density.
- `discovery.indexed` (90 pages): image assets and the new `llms.txt`/`sitemap.md`/`sitemap.xml`/`llms-full.txt` URLs which are themselves indexes.
- Six checks on `/cdn-cgi/l/email-protection`: Cloudflare intercept page.

## New scope unlocked by publishing .md mirrors (candidates for a follow-up PR)

Publishing 37 `.md` mirrors moved 2578 previously-skipped checks into scope. The lowest-hanging follow-ups:

- `html.json-ld.breadcrumb` (37 pages): add a `BreadcrumbList` block alongside the existing `TechArticle`.
- `html.json-ld.date-modified` (37 pages): add `dateModified` to the JSON-LD payload from `page.update_date` or git mtime.
- `markdown.canonical-header` (37 pages): `.md` mirrors should declare their canonical HTML URL at the top.
- `markdown.frontmatter` (37 pages): `.md` mirrors should expose YAML frontmatter with title/description/canonical/date.
- `markdown.sitemap-section` (37 pages): `sitemap.md` should split into section headers (the `mkdocs.yml` nav groups are the obvious mapping).

## Share-ready summary

If you want to post about it:

```
docs.reccehq.com scored 72/100 for Agent Readability — up from 66 after today's fixes.

Scorecard v0.2.0 · 989/1372 checks passed

Audit your own site at https://a14y.dev?utm_source=skill&utm_medium=share
```

And if you want to publish the score on the site, here is the embeddable badge URL:

```
https://a14y.dev/badge/?s=72&v=0.2.0&a=1372&t=3950&p=989&f=383&w=0&e=0&n=2578&d=2026-05-11&m=site&u=https%3A%2F%2Fdocs.reccehq.com%2F
```

## Test plan

- [x] Re-ran `a14y check https://docs.reccehq.com --mode site` against the live site, confirmed score and resolved-check list.
- [x] Appended the new run to the `Last runs:` list in `docs/AGENTS.md`, newest first.

Generated with [Claude Code](https://claude.com/claude-code)
