### PR TITLE
docs(setup): caveat state_modified_compare_more_unrendered_values

### DIFF
--- a/docs/setup-guides/environment-best-practices.md
+++ b/docs/setup-guides/environment-best-practices.md
@@ -64,6 +64,19 @@ Unchanged models are resolved from production via `--defer`, so you only pay for
 
 For many projects, this is the complete setup.
 
+!!! warning "Set `state_modified_compare_more_unrendered_values` if your configs reference environment values"
+    By default, dbt's `state:modified` compares **rendered** config values. If your models use environment-aware Jinja inside configs — `incremental_predicates`, `unique_key`, or `partition_by` referencing `{{ this }}`, `{{ target.schema }}`, env vars, etc. — the same model renders to different values in base vs. PR environments. dbt flags them as modified and Recce surfaces them as altered, even though the source code is identical.
+
+    Enable the [`state_modified_compare_more_unrendered_values`](https://docs.getdbt.com/reference/global-configs/behavior-changes#source-definitions-for-statemodified) flag (dbt >= 1.9) so dbt compares the unrendered Jinja source instead:
+
+    ```yaml
+    # dbt_project.yml
+    flags:
+      state_modified_compare_more_unrendered_values: True
+    ```
+
+    Both base and current manifests must be built with the flag enabled — rebuild your base artifacts if they predate this change, or `state:modified` will keep producing false positives.
+
 ## Keep Your Base Environment Current
 
 The base environment can become outdated in two scenarios:

--- a/docs/setup-guides/environment-best-practices.md
+++ b/docs/setup-guides/environment-best-practices.md
@@ -65,14 +65,14 @@ Unchanged models are resolved from production via `--defer`, so you only pay for
 For many projects, this is the complete setup.
 
 !!! warning "Set `state_modified_compare_more_unrendered_values` if your configs reference environment values"
-    By default, dbt's `state:modified` compares **rendered** config values. If your models use environment-aware Jinja inside configs — `incremental_predicates`, `unique_key`, or `partition_by` referencing `{{ this }}`, `{{ target.schema }}`, env vars, etc. — the same model renders to different values in base vs. PR environments. dbt flags them as modified and Recce surfaces them as altered, even though the source code is identical.
+    By default, dbt's `state:modified` compares **rendered** config values. Configs like `incremental_predicates`, `unique_key`, or `partition_by` often contain environment-aware Jinja such as `{{ this }}`, `{{ target.schema }}`, or env vars. Those configs render to different values across base and current environments, so dbt flags the model as modified and Recce surfaces it as altered — even though the source code is identical.
 
     Enable the [`state_modified_compare_more_unrendered_values`](https://docs.getdbt.com/reference/global-configs/behavior-changes#source-definitions-for-statemodified) flag (dbt >= 1.9) so dbt compares the unrendered Jinja source instead:
 
     ```yaml
     # dbt_project.yml
     flags:
-      state_modified_compare_more_unrendered_values: True
+      state_modified_compare_more_unrendered_values: true
     ```
 
     Both base and current manifests must be built with the flag enabled — rebuild your base artifacts if they predate this change, or `state:modified` will keep producing false positives.


### PR DESCRIPTION
## Summary

- Customer in Slack (dev-duty thread) lost hours debugging Recce "altered models" false positives caused by dbt's default `state:modified` comparing **rendered** config values: `incremental_predicates` referencing `{{ this }}` / `target.schema` render to different schemas across base vs. CI environments, so identical source code gets flagged as modified.
- Adds a warning admonition to `docs/setup-guides/environment-best-practices.md`, immediately after the "Slim CI Works Out of the Box" section (where `state:modified` is introduced), explaining the symptom, the fix (`state_modified_compare_more_unrendered_values` behavior flag, dbt >= 1.9), the `dbt_project.yml` syntax, and the critical caveat that **both base and current manifests** must be built with the flag enabled — base artifacts must be rebuilt if they predate the flag.

## Test plan

- [x] `mkdocs build` succeeds without new errors (pre-existing cairosvg/social-card warnings unrelated)
- [x] Verified rendered HTML in `site/setup-guides/environment-best-practices/index.html` — admonition title, paragraphs, code block, and dbt-docs link all render correctly
- [ ] Reviewer: confirm placement (Slim CI section is the right neighbor) and tone (matches surrounding "Seeing Unexpected Diffs?" voice)

<img width="1440" height="1100" alt="caveat-closeup" src="https://github.com/user-attachments/assets/df29680e-631e-4265-b97d-180747197681" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)