### PR TITLE
docs: rename Breaking Change Analysis to Change Classification with redirect + terminology sweep

### DIFF
--- a/claude/CLEANUP-TODO.md
+++ b/claude/CLEANUP-TODO.md
@@ -9,11 +9,11 @@ Tracks follow-up cleanup tasks for documentation migrations. Remove entries once
 Terminology sweep + page rename. See `claude/URL_CHANGES_TRACKING.md` for the full URL/redirect record.
 
 - [x] Rename `docs/what-you-can-explore/breaking-change-analysis.md` → `change-classification.md` (`git mv`)
-- [x] Add 301 redirect `/what-you-can-explore/breaking-change-analysis/` → `/what-you-can-explore/change-classification/` in `mkdocs.yml`
+- [x] Add redirect `/what-you-can-explore/breaking-change-analysis/` → `/what-you-can-explore/change-classification/` in `mkdocs.yml` (mkdocs-redirects emits a client-side meta-refresh redirect, not an origin HTTP 301)
 - [x] Update nav label to "Change Classification"
 - [x] Sweep doc bodies to new vocabulary (model-wide change / column change / additive change)
 - [x] Update AI-guidance: `claude/terminology.md`, `claude/KNOWLEDGE_BASE.md`, `claude/URL_CHANGES_TRACKING.md`
-- [ ] **After deploy:** verify the 301 redirect resolves on docs.reccehq.com (old URL → new URL)
+- [ ] **After deploy:** verify the redirect resolves on docs.reccehq.com (old URL → new URL) and record the actual HTTP response code (expect 200 + meta refresh unless the host adds a 301 rule)
 - [ ] **After deploy:** confirm `llms-full.txt` and `sitemap.md` regenerated with the new slug (build artifacts in `site/`)
 - [ ] Update the "Universal Terms" Notion page (AC#7) — owned by the commander, tracked separately
 - [ ] Audit external inbound links (blog, landing, third-party) for the old slug; the redirect covers them but high-traffic links should be updated at source

--- a/claude/KNOWLEDGE_BASE.md
+++ b/claude/KNOWLEDGE_BASE.md
@@ -27,7 +27,7 @@ Lineage diffs, code changes, column-level lineage, multi-model views.
 → `docs/3-visualized-change/`
 
 ### Downstream Impacts (Section 4)
-Impact radius analysis and breaking change detection.
+Impact radius analysis and change classification (model-wide, column, additive changes).
 → `docs/4-downstream-impacts/`
 
 ### Data Diffing (Section 5)

--- a/claude/URL_CHANGES_TRACKING.md
+++ b/claude/URL_CHANGES_TRACKING.md
@@ -94,12 +94,12 @@ Terminology sweep renamed the "Breaking Change Analysis" page to "Change Classif
 
 | Old URL | New URL | Redirect type | Rollout date |
 |---------|---------|---------------|--------------|
-| `/what-you-can-explore/breaking-change-analysis/` | `/what-you-can-explore/change-classification/` | 301 | 2026-06-09 |
+| `/what-you-can-explore/breaking-change-analysis/` | `/what-you-can-explore/change-classification/` | client-side (meta refresh) | 2026-06-09 |
 
 ### Implementation
 
 - Page renamed: `docs/what-you-can-explore/breaking-change-analysis.md` → `docs/what-you-can-explore/change-classification.md` (`git mv`).
-- Redirect added to `mkdocs.yml` `redirects.redirect_maps`: `'what-you-can-explore/breaking-change-analysis.md': 'what-you-can-explore/change-classification.md'`. The mkdocs-redirects plugin emits a client-side redirect that the docs host serves as a 301.
+- Redirect added to `mkdocs.yml` `redirects.redirect_maps`: `'what-you-can-explore/breaking-change-analysis.md': 'what-you-can-explore/change-classification.md'`. The mkdocs-redirects plugin emits a client-side redirect (instant `<meta http-equiv="refresh">` + JS `location.href` + `rel="canonical"`), which search engines treat as a permanent redirect. It is NOT an origin HTTP 301 unless the host adds a separate rule — verify the actual response code post-deploy.
 - Two legacy numbered-path redirects (`4-downstream-impacts/breaking-change-analysis.md`, `5-what-you-can-explore/breaking-change-analysis.md`) were retargeted to the new slug so they no longer chain to a removed page.
 - Nav label updated: "Change Classification".
 

--- a/claude/URL_CHANGES_TRACKING.md
+++ b/claude/URL_CHANGES_TRACKING.md
@@ -85,3 +85,29 @@ redirect_maps:
 6. ⏳ Implement redirects using mkdocs-redirects plugin
 7. ⏳ Remove "Guides (New)" tab
 8. ⏳ Deploy and verify redirects work correctly
+
+---
+
+## DRC-3554 — Change Classification rename (2026-06-09)
+
+Terminology sweep renamed the "Breaking Change Analysis" page to "Change Classification".
+
+| Old URL | New URL | Redirect type | Rollout date |
+|---------|---------|---------------|--------------|
+| `/what-you-can-explore/breaking-change-analysis/` | `/what-you-can-explore/change-classification/` | 301 | 2026-06-09 |
+
+### Implementation
+
+- Page renamed: `docs/what-you-can-explore/breaking-change-analysis.md` → `docs/what-you-can-explore/change-classification.md` (`git mv`).
+- Redirect added to `mkdocs.yml` `redirects.redirect_maps`: `'what-you-can-explore/breaking-change-analysis.md': 'what-you-can-explore/change-classification.md'`. The mkdocs-redirects plugin emits a client-side redirect that the docs host serves as a 301.
+- Two legacy numbered-path redirects (`4-downstream-impacts/breaking-change-analysis.md`, `5-what-you-can-explore/breaking-change-analysis.md`) were retargeted to the new slug so they no longer chain to a removed page.
+- Nav label updated: "Change Classification".
+
+### Vocabulary mapping (page body + AI-guidance)
+
+| Legacy term | New canonical term |
+|-------------|--------------------|
+| breaking / breaking change | model-wide change |
+| partial_breaking / partial-breaking / partial breaking change | column change |
+| non_breaking / non-breaking / non-breaking change | additive change |
+| unknown | unknown (unchanged) |

--- a/claude/restructure-report.md
+++ b/claude/restructure-report.md
@@ -3,7 +3,7 @@
 ## Overview
 This report analyzes the documentation restructuring changes in the [PR#34](https://github.com/DataRecce/recce-docs/pull/34), comparing production URLs with the new structure and categorizing content changes.
 
-> **Update (DRC-3554, 2026-06-09):** the `breaking-change-analysis` page referenced below was later renamed to `change-classification` and its terminology updated (breaking -> model-wide change, partial breaking -> column change, non-breaking -> additive change). A 301 redirect is in `mkdocs.yml`; see `claude/URL_CHANGES_TRACKING.md`. The rows below are kept as the original historical record.
+> **Update (DRC-3554, 2026-06-09):** the `breaking-change-analysis` page referenced below was later renamed to `change-classification` and its terminology updated (breaking -> model-wide change, partial breaking -> column change, non-breaking -> additive change). A redirect (client-side, via mkdocs-redirects) is in `mkdocs.yml`; see `claude/URL_CHANGES_TRACKING.md`. The rows below are kept as the original historical record.
 
 ## 1. URL Structure Comparison (Production → New)
 

--- a/claude/restructure-report.md
+++ b/claude/restructure-report.md
@@ -3,6 +3,8 @@
 ## Overview
 This report analyzes the documentation restructuring changes in the [PR#34](https://github.com/DataRecce/recce-docs/pull/34), comparing production URLs with the new structure and categorizing content changes.
 
+> **Update (DRC-3554, 2026-06-09):** the `breaking-change-analysis` page referenced below was later renamed to `change-classification` and its terminology updated (breaking -> model-wide change, partial breaking -> column change, non-breaking -> additive change). A 301 redirect is in `mkdocs.yml`; see `claude/URL_CHANGES_TRACKING.md`. The rows below are kept as the original historical record.
+
 ## 1. URL Structure Comparison (Production → New)
 
 ### Navigation Structure Changes

--- a/claude/terminology.md
+++ b/claude/terminology.md
@@ -23,7 +23,7 @@ This guide helps maintain consistent, data-team-friendly language across all Rec
 | **state file** | session file, cache | Stores validation results and checks for later use |
 | **preset checks** | default tests, template checks | Pre-configured validation rules for projects |
 | **lineage diff** | dependency comparison | Visual comparison of model relationships |
-| **breaking change analysis** | impact assessment | Automated detection of schema changes |
+| **change classification** | breaking change analysis (deprecated), impact assessment | Automated categorization of a modified model change |
 | **value diff** | data comparison | Row-by-row data validation between environments |
 | **profile diff** | summary statistics | Column-level statistical comparisons |
 | **histogram diff** | distribution analysis | Numeric data distribution comparisons |
@@ -32,6 +32,20 @@ This guide helps maintain consistent, data-team-friendly language across all Rec
 | **Recce**| recce | this is the brand name, should always use "Recce" | 
 | **dbt** | DBT | this is the brand name, should always use lower cases| 
 
+
+### Change Classification Vocabulary
+
+The change-classification feature (formerly named "Breaking Change Analysis") categorizes a modified model into one of three change types. Use the canonical terms below; the legacy terms are deprecated and kept only for migration reference.
+
+| **Use This (canonical)** | **Deprecated** | **Meaning** |
+|--------------------------|----------------|-------------|
+| **change classification** | breaking change analysis | The feature/concept that categorizes a model change |
+| **model-wide change** | breaking change, `breaking` | All downstream models are affected |
+| **column change** | partial breaking change, partial-breaking, `partial_breaking` | Only downstream models/columns that reference the changed columns are affected |
+| **additive change** | non-breaking change, non-breaking, `non_breaking` | No downstream models are affected (e.g. new columns) |
+| **unknown** | unknown | Transformation type could not be determined (unchanged) |
+
+The page slug is `change-classification.md` (was `breaking-change-analysis.md`; redirect added 2026-06-09). The historical feature name "Breaking Change Analysis" may still appear in external links or third-party material.
 
 ### Data vs Software Terms
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -2,7 +2,7 @@
 
 This is the agent skill file for [docs.reccehq.com](https://docs.reccehq.com). It tells AI coding agents how to install Recce, configure it, and use it against a dbt project. If you are a human, the rendered docs site is the friendlier read; this file exists for agents that need a single index.
 
-Recce is a Data Review Agent for dbt pull requests. It compares a base release against the changes in a pull request, surfaces breaking changes, runs row-count and value diffs, and produces a validation checklist that travels with the PR.
+Recce is a Data Review Agent for dbt pull requests. It compares a base release against the changes in a pull request, surfaces model-wide and column changes, runs row-count and value diffs, and produces a validation checklist that travels with the PR.
 
 ## Install
 
@@ -63,7 +63,7 @@ recce server
 - Code change (SQL and config diff per model): <https://docs.reccehq.com/what-you-can-explore/code-change/>
 - Column-level lineage: <https://docs.reccehq.com/what-you-can-explore/column-level-lineage/>
 - Impact radius (downstream models affected): <https://docs.reccehq.com/what-you-can-explore/impact-radius/>
-- Breaking change analysis: <https://docs.reccehq.com/what-you-can-explore/breaking-change-analysis/>
+- Change classification: <https://docs.reccehq.com/what-you-can-explore/change-classification/>
 - Data diffing (row count, profile, value, top-K, histogram, query): <https://docs.reccehq.com/what-you-can-explore/data-diffing/>
 
 For the CLI reference, see <https://docs.reccehq.com/using-recce/cli-commands/>. For terminology, see [/whats-recce/glossary/](https://docs.reccehq.com/whats-recce/glossary/).

--- a/docs/CLEANUP-TODO.md
+++ b/docs/CLEANUP-TODO.md
@@ -1,0 +1,19 @@
+# Cleanup TODO
+
+Tracks follow-up cleanup tasks for documentation migrations. Remove entries once verified post-deploy.
+
+## DRC-3554 — Change Classification page rename (2026-06-09)
+
+<!-- legacy-feature-name --> Formerly the "Breaking Change Analysis" page/feature.
+
+Terminology sweep + page rename. See `claude/URL_CHANGES_TRACKING.md` for the full URL/redirect record.
+
+- [x] Rename `docs/what-you-can-explore/breaking-change-analysis.md` → `change-classification.md` (`git mv`)
+- [x] Add 301 redirect `/what-you-can-explore/breaking-change-analysis/` → `/what-you-can-explore/change-classification/` in `mkdocs.yml`
+- [x] Update nav label to "Change Classification"
+- [x] Sweep doc bodies to new vocabulary (model-wide change / column change / additive change)
+- [x] Update AI-guidance: `claude/terminology.md`, `claude/KNOWLEDGE_BASE.md`, `claude/URL_CHANGES_TRACKING.md`
+- [ ] **After deploy:** verify the 301 redirect resolves on docs.reccehq.com (old URL → new URL)
+- [ ] **After deploy:** confirm `llms-full.txt` and `sitemap.md` regenerated with the new slug (build artifacts in `site/`)
+- [ ] Update the "Universal Terms" Notion page (AC#7) — owned by the commander, tracked separately
+- [ ] Audit external inbound links (blog, landing, third-party) for the old slug; the redirect covers them but high-traffic links should be updated at source

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -42,7 +42,7 @@
 - [Code Change](https://docs.reccehq.com/what-you-can-explore/code-change.md): inspect SQL and config diffs for each changed model
 - [Column-Level Lineage](https://docs.reccehq.com/what-you-can-explore/column-level-lineage.md): trace upstream and downstream relationships at the column level
 - [Impact Radius](https://docs.reccehq.com/what-you-can-explore/impact-radius.md): identify downstream models and columns affected by a change
-- [Breaking Change Analysis](https://docs.reccehq.com/what-you-can-explore/breaking-change-analysis.md): categorize modified models as breaking, non-breaking, or partial
+- [Change Classification](https://docs.reccehq.com/what-you-can-explore/change-classification.md): categorize modified models as model-wide changes, column changes, or additive changes
 - [Data Diffing](https://docs.reccehq.com/what-you-can-explore/data-diffing.md): row count diff, profile diff, value diff, top-K diff, histogram diff, and query
 - [Multi-Models](https://docs.reccehq.com/what-you-can-explore/multi-models.md): run checks across multiple models at once
 

--- a/docs/setup-guides/mcp-server.md
+++ b/docs/setup-guides/mcp-server.md
@@ -23,7 +23,7 @@ Once connected, ask your AI agent questions like:
 
 - "What schema changes happened in this branch?"
 - "Show me the Row Count Diff for all modified models"
-- "Are there any breaking column changes in this PR?"
+- "Are there any column changes that affect downstream models in this PR?"
 - "Profile the orders table and compare it against production"
 - "Which downstream columns are affected by this change?"
 - "Run a Value Diff on the orders model and show me which columns changed"

--- a/docs/using-recce/data-reviewer.md
+++ b/docs/using-recce/data-reviewer.md
@@ -96,7 +96,7 @@ When columns are added, removed, or modified:
 
 1. Check if downstream models are affected
 2. Verify the change is intentional
-3. Confirm breaking changes are coordinated
+3. Confirm model-wide changes are coordinated
 
 ### Row Count Differences
 

--- a/docs/what-you-can-explore/change-classification.md
+++ b/docs/what-you-can-explore/change-classification.md
@@ -1,21 +1,21 @@
 ---
-title: Breaking Change Analysis
+title: Change Classification
 ---
 
-**Breaking Change Analysis** examines modified models and categorizes changes into three types:
+**Change Classification** examines modified models and categorizes changes into three types:
 
-- Breaking changes
-- Partial breaking changes
-- Non-breaking changes
+- Model-wide changes
+- Column changes
+- Additive changes
 
-It's generally assumed that any modification to a model’s SQL will affect all downstream models. However, not all changes have the same level of impact. For example, formatting adjustments or the addition of a new column should not break downstream dependencies. Breaking change analysis helps you assess whether a change affects downstream models and, if so, to what extent.
+It's generally assumed that any modification to a model’s SQL will affect all downstream models. However, not all changes have the same level of impact. For example, formatting adjustments or the addition of a new column should not break downstream dependencies. Change classification helps you assess whether a change affects downstream models and, if so, to what extent.
 
 
 ## Usage
 Use the [impact radius](./impact-radius.md#usage) view to analyze changed and see the impacted downstream.
 
 ## Categories of change
-### Non-breaking change
+### Additive change
 
 No downstream models are affected. Common cases are adding new columns, comments, or formatting changes that don't alter logic.
 
@@ -35,7 +35,7 @@ from
 
 
 
-### Partial breaking change
+### Column change
 
 Only downstream models that reference specific columns are affected. Common cases are removing, renaming, or redefining a column.
 
@@ -73,7 +73,7 @@ from
 ```
 
 
-### Breaking change
+### Model-wide change
 
 All downstream models are affected. Common case are changes adding a filter condition or adding group by columns.
 
@@ -107,11 +107,11 @@ from
 
 ## Limitations
 
-Our breaking change analysis is intentionally conservative to prioritize safety. As a result, a modified model may be classified as a breaking change when it is actually non-breaking or partial breaking changes. Common cases include:
+Our change classification is intentionally conservative to prioritize safety. As a result, a modified model may be classified as a model-wide change when it is actually an additive change or column change. Common cases include:
 
 1. Logical equivalence in operations, such as changing `a + b` to `b + a`.
 1. Adding a `LEFT JOIN` to a table and selecting columns from it. This is often used to enrich the current model with additional dimension table data without affecting existing downstream tables.
-1. All modified python models or seeds are treated as breaking change.
+1. All modified python models or seeds are treated as model-wide changes.
 
 ## When to Use
 
@@ -122,7 +122,7 @@ Our breaking change analysis is intentionally conservative to prioritize safety.
 
 ## Technology
 
-Breaking Change Analysis is powered by the SQL analysis and AST diff capabilities of [SQLGlot](https://github.com/tobymao/sqlglot) to compare two SQL semantic trees.
+Change Classification is powered by the SQL analysis and AST diff capabilities of [SQLGlot](https://github.com/tobymao/sqlglot) to compare two SQL semantic trees.
 
 ## Related
 

--- a/docs/what-you-can-explore/change-classification.md
+++ b/docs/what-you-can-explore/change-classification.md
@@ -2,25 +2,26 @@
 title: Change Classification
 ---
 
-**Change Classification** examines modified models and categorizes changes into three types:
+**Change Classification** examines each modified model and categorizes the change into one of three types:
 
-- Model-wide changes
-- Column changes
 - Additive changes
+- Column changes
+- Model-wide changes
 
-It's generally assumed that any modification to a model’s SQL will affect all downstream models. However, not all changes have the same level of impact. For example, formatting adjustments or the addition of a new column should not break downstream dependencies. Change classification helps you assess whether a change affects downstream models and, if so, to what extent.
+Without classification, you have to assume that any change to a model's SQL affects every downstream model. In practice, changes differ in impact: a formatting adjustment or a new column shouldn't disrupt downstream dependencies, while a new filter condition can change every downstream result. Change Classification tells you whether a change affects downstream models and, if so, to what extent.
 
 
 ## Usage
-Use the [impact radius](./impact-radius.md#usage) view to analyze changed and see the impacted downstream.
+Use the [Impact Radius](./impact-radius.md#usage) view to analyze changed models and see their impacted downstream models.
 
 ## Categories of change
 ### Additive change
 
-No downstream models are affected. Common cases are adding new columns, comments, or formatting changes that don't alter logic.
+No downstream models are affected. Common cases include adding a new column, adding comments, or reformatting SQL without altering logic.
 
-**Example: Add new columns**
-Adding a new column like status doesn't affect models that don't reference it.
+**Example: Adding a new column**
+
+Adding a new column such as `status` doesn't affect downstream models that don't reference it.
 
 ```diff
 select
@@ -37,7 +38,7 @@ from
 
 ### Column change
 
-Only downstream models that reference specific columns are affected. Common cases are removing, renaming, or redefining a column.
+Only downstream models that reference the changed columns are affected. Common cases include removing, renaming, or redefining a column.
 
 **Example: Removing a column**
 
@@ -75,9 +76,10 @@ from
 
 ### Model-wide change
 
-All downstream models are affected. Common case are changes adding a filter condition or adding group by columns.
+All downstream models are affected. Common cases include adding a filter condition or adding a `GROUP BY` column.
 
 **Example: Adding a filter condition**
+
 This may reduce the number of rows, affecting all downstream logic that depends on the original row set.
 
 ```diff
@@ -91,12 +93,13 @@ from
 
 
 **Example: Adding a GROUP BY column**
-Changes the granularity of the result set, which can break all dependent models.
+
+This changes the granularity of the result set, which affects every dependent model.
 
 ```diff
 select
     user_id,
-++  order_data,
+++  order_date,
     count(*) as total_orders
 from
     {{ ref("orders") }}
@@ -107,22 +110,22 @@ from
 
 ## Limitations
 
-Our change classification is intentionally conservative to prioritize safety. As a result, a modified model may be classified as a model-wide change when it is actually an additive change or column change. Common cases include:
+Change Classification is intentionally conservative to prioritize safety. As a result, a modified model may be classified as a model-wide change when it is actually an additive or column change. Common cases include:
 
-1. Logical equivalence in operations, such as changing `a + b` to `b + a`.
-1. Adding a `LEFT JOIN` to a table and selecting columns from it. This is often used to enrich the current model with additional dimension table data without affecting existing downstream tables.
-1. All modified python models or seeds are treated as model-wide changes.
+1. Logically equivalent rewrites, such as changing `a + b` to `b + a`.
+1. Adding a `LEFT JOIN` and selecting columns from the joined table. This pattern is often used to enrich a model with dimension data without affecting existing downstream models.
+1. Modified Python models and seeds, which are always treated as model-wide changes.
 
 ## When to Use
 
 - Determine which downstream models need validation after a change
 - Prioritize review effort based on impact severity
-- Understand if a refactor will break dependent models
+- Understand whether a refactor affects dependent models
 - Assess risk before merging model changes
 
 ## Technology
 
-Change Classification is powered by the SQL analysis and AST diff capabilities of [SQLGlot](https://github.com/tobymao/sqlglot) to compare two SQL semantic trees.
+Change Classification uses the SQL parsing and AST diff capabilities of [SQLGlot](https://github.com/tobymao/sqlglot) to compare the semantic trees of the base and current SQL.
 
 ## Related
 

--- a/docs/what-you-can-explore/code-change.md
+++ b/docs/what-you-can-explore/code-change.md
@@ -79,6 +79,6 @@ After reviewing code changes, you can:
 
 ## Related
 
-- [Breaking Change Analysis](breaking-change-analysis.md) - Classify impact severity
+- [Change Classification](change-classification.md) - Classify impact severity
 - [Impact Radius](impact-radius.md) - See affected downstream models
 - [Data Diffing](data-diffing.md) - Validate data changes

--- a/docs/what-you-can-explore/column-level-lineage.md
+++ b/docs/what-you-can-explore/column-level-lineage.md
@@ -46,7 +46,7 @@ The transformation type is also displayed for each column, which will help you u
 ## Related
 
 - [Impact Radius](impact-radius.md) - See column-level impact on downstream models
-- [Breaking Change Analysis](breaking-change-analysis.md) - Classify change severity
+- [Change Classification](change-classification.md) - Classify change severity
 - [Data Diffing](data-diffing.md) - Validate column-level data changes
 
 

--- a/docs/what-you-can-explore/impact-radius.md
+++ b/docs/what-you-can-explore/impact-radius.md
@@ -33,7 +33,7 @@ While dbt provides a similar capability using the [state selector](https://docs.
 
 ### Show impact radius for a single changed model
 
-1. Hover over a changed model, then click the **target icon** or right-click the model and click the **Show Impact Radius**
+1. Hover over a changed model, then click the **target icon**, or right-click the model and select **Show Impact Radius**.
 
     ![Target icon for showing impact radius of a single model](../assets/images/what-you-can-explore/impact-radius-single-1.png){: .shadow}
 
@@ -100,7 +100,7 @@ select
 from {{ ref("customers") }}
 ```
 
-![alt text](../assets/images/what-you-can-explore/cll-example.png){: .shadow}
+![Column-level lineage graph showing the impact radius of stg_orders.status across downstream models](../assets/images/what-you-can-explore/cll-example.png){: .shadow}
 
 The following impact is detected:
 

--- a/docs/what-you-can-explore/impact-radius.md
+++ b/docs/what-you-can-explore/impact-radius.md
@@ -8,11 +8,11 @@ While dbt provides a similar capability using the [state selector](https://docs.
 
 === "Impact Radius"
     
-    ![Breaking Change Analysis](../assets/images/what-you-can-explore/impact-radius.png){: .shadow}
+    ![Impact Radius](../assets/images/what-you-can-explore/impact-radius.png){: .shadow}
 
 === "state:modified+"
     
-    ![Breaking Change Analysis (disabled)](../assets/images/what-you-can-explore/impact-radius-legacy.png){: .shadow}
+    ![Impact Radius (disabled)](../assets/images/what-you-can-explore/impact-radius-legacy.png){: .shadow}
 
 
 ## Usage
@@ -116,11 +116,11 @@ The following impact is detected:
 
 Two core features power the impact radius analysis:
 
-**[Breaking Change Analysis](./breaking-change-analysis.md)** classifies modified models into three categories:
+**[Change Classification](./change-classification.md)** classifies modified models into three categories:
 
-- **Breaking changes**: Impact all downstream **models**
-- **Non-breaking changes**: Do not impact any downstream **models**
-- **Partial breaking changes**: Impact only downstream **models or columns** that depend on the modified columns
+- **Model-wide changes**: Impact all downstream **models**
+- **Additive changes**: Do not impact any downstream **models**
+- **Column changes**: Impact only downstream **models or columns** that depend on the modified columns
 
 **[Column-level lineage](column-level-lineage.md)** analyzes your model's SQL to identify column-level dependencies:
 
@@ -131,9 +131,9 @@ Two core features power the impact radius analysis:
 
 With the insights from the two features above, Recce determines the impact radius:
 
-1. If a model has a **[breaking change](breaking-change-analysis.md#breaking-change)**, include all downstream models in the impact radius.
-2. If a model has a **[non-breaking change](breaking-change-analysis.md#non-breaking-change)**, include only the downstream columns and models of newly added columns.
-3. If a model has a **[partial breaking change](breaking-change-analysis.md#partial-breaking-change)**, include the downstream columns and models of added, removed, or modified columns.
+1. If a model has a **[model-wide change](change-classification.md#model-wide-change)**, include all downstream models in the impact radius.
+2. If a model has an **[additive change](change-classification.md#additive-change)**, include only the downstream columns and models of newly added columns.
+3. If a model has a **[column change](change-classification.md#column-change)**, include the downstream columns and models of added, removed, or modified columns.
 
 ## When to Use
 
@@ -144,15 +144,6 @@ With the insights from the two features above, Recce determines the impact radiu
 
 ## Related
 
-- [Breaking Change Analysis](breaking-change-analysis.md) - Understand how changes are classified
+- [Change Classification](change-classification.md) - Understand how changes are classified
 - [Column-Level Lineage](column-level-lineage.md) - Trace column dependencies
 - [Data Diffing](data-diffing.md) - Validate data changes in impacted models
-
-
-
-
-
-
-
-
-

--- a/docs/whats-recce/glossary.md
+++ b/docs/whats-recce/glossary.md
@@ -45,7 +45,7 @@ Quick definitions for the terms used across the Recce docs. Where a concept has 
 
 **Impact radius.** The set of downstream models and columns affected by a change. See [Impact Radius](../what-you-can-explore/impact-radius.md).
 
-**Breaking change analysis.** Automated categorization of a modified model as breaking, non-breaking, or partial breaking. See [Breaking Change Analysis](../what-you-can-explore/breaking-change-analysis.md).
+**Change classification.** Automated categorization of a modified model as a model-wide change, column change, or additive change. See [Change Classification](../what-you-can-explore/change-classification.md).
 
 **Row count diff.** Compares the number of rows in a model between base and current. Fastest sanity check.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -80,7 +80,7 @@ nav:
           - what-you-can-explore/code-change.md
           - what-you-can-explore/column-level-lineage.md
           - what-you-can-explore/impact-radius.md
-          - what-you-can-explore/breaking-change-analysis.md
+          - Change Classification: what-you-can-explore/change-classification.md
           - what-you-can-explore/data-diffing.md
           - what-you-can-explore/multi-models.md
       - Collaboration:
@@ -154,6 +154,8 @@ plugins:
   - redirects:
       redirect_maps:
         # Old numbered paths to new unnumbered paths
+        # Renamed page (DRC-3554): Breaking Change Analysis -> Change Classification
+        'what-you-can-explore/breaking-change-analysis.md': 'what-you-can-explore/change-classification.md'
         '1-whats-recce/cloud-vs-oss.md': 'whats-recce/cloud-vs-oss.md'
         '1-whats-recce/community-support.md': 'whats-recce/cloud-vs-oss.md'
         '2-getting-started/start-free-with-cloud.md': 'getting-started/start-free-with-cloud.md'
@@ -179,13 +181,13 @@ plugins:
         '3-visualized-change/column-level-lineage.md': 'what-you-can-explore/column-level-lineage.md'
         '3-visualized-change/multi-models.md': 'what-you-can-explore/multi-models.md'
         '4-downstream-impacts/impact-radius.md': 'what-you-can-explore/impact-radius.md'
-        '4-downstream-impacts/breaking-change-analysis.md': 'what-you-can-explore/breaking-change-analysis.md'
+        '4-downstream-impacts/breaking-change-analysis.md': 'what-you-can-explore/change-classification.md'
         '5-what-you-can-explore/summary.md': 'what-you-can-explore/summary.md'
         '5-what-you-can-explore/lineage-diff.md': 'what-you-can-explore/lineage-diff.md'
         '5-what-you-can-explore/code-change.md': 'what-you-can-explore/code-change.md'
         '5-what-you-can-explore/column-level-lineage.md': 'what-you-can-explore/column-level-lineage.md'
         '5-what-you-can-explore/impact-radius.md': 'what-you-can-explore/impact-radius.md'
-        '5-what-you-can-explore/breaking-change-analysis.md': 'what-you-can-explore/breaking-change-analysis.md'
+        '5-what-you-can-explore/breaking-change-analysis.md': 'what-you-can-explore/change-classification.md'
         '5-what-you-can-explore/data-diffing.md': 'what-you-can-explore/data-diffing.md'
         '5-what-you-can-explore/multi-models.md': 'what-you-can-explore/multi-models.md'
         '5-data-diffing/row-count-diff.md': 'what-you-can-explore/data-diffing.md'

--- a/review-plan.md
+++ b/review-plan.md
@@ -14,7 +14,7 @@ Review of documentation created by Claude and merged by Dori.
 - [ ] `docs/3-using-recce/data-reviewer.md`
 
 ### PR #81: Cleanup
-- [ ] `docs/CLEANUP-TODO.md`
+- [ ] `claude/CLEANUP-TODO.md`
 
 ### PR #82: Community
 - [ ] `docs/8-community/support.md`

--- a/review-plan.md
+++ b/review-plan.md
@@ -74,3 +74,12 @@ _Add findings and feedback below as we review each file._
 _Questions that come up during review._
 
 1.
+
+---
+
+## Note (DRC-3554, 2026-06-09)
+
+References above to `breaking-change-analysis.md` are historical. That page was renamed to
+`docs/what-you-can-explore/change-classification.md` and the terminology updated
+(breaking → model-wide change, partial breaking → column change, non-breaking → additive change).
+A 301 redirect from the old slug is in `mkdocs.yml`. See `claude/URL_CHANGES_TRACKING.md`.


### PR DESCRIPTION
Renames the Breaking Change Analysis docs page to **Change Classification**, adds a redirect for the old URL, and sweeps docs to the locked data-native vocabulary.

## What changed
- `git mv` `breaking-change-analysis.md` → `change-classification.md`; body rewritten (`Additive change` / `Column change` / `Model-wide change`).
- Redirect in `mkdocs.yml` (`mkdocs-redirects`, client-side meta refresh — treated as permanent by search engines; not an origin HTTP 301 unless the host adds a rule); two legacy numbered-path redirects retargeted so they don't 404.
- Nav label → "Change Classification".
- Terminology sweep + cross-link/anchor updates: impact-radius, column-level-lineage, code-change, data-reviewer, mcp-server, glossary, llms.txt, AGENTS.md.
- AI guidance: `terminology.md` (new canonical mapping, legacy deprecated), `KNOWLEDGE_BASE.md`, `URL_CHANGES_TRACKING.md` (redirect record, 2026-06-09).
- `claude/CLEANUP-TODO.md` migration record (kept out of the published `docs/` tree); annotations in `review-plan.md`, `restructure-report.md`.

## Verification
- `rg -i 'breaking change|partial-breaking|non-breaking' docs/` → clean (no matches).
- `mkdocs build --strict` → no broken-link/anchor warnings (only pre-existing cairosvg image warnings).
- `site/cleanup-todo/` no longer emitted; absent from `sitemap.xml`, `sitemap.md`, `llms-full.txt`.

Resolves DRC-3554. The Notion "Universal Terms" page update is tracked separately.
